### PR TITLE
Add python-magic package in pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setuptools.setup(
     keywords=["cord"],
     install_requires=[
         "requests",
+        "python-magic"
     ],
 )


### PR DESCRIPTION
In Linux when installing 'cord-client-python 0.1.3' with pip there is a missing package (python-magic) that can be found in 'requirements.txt'.

Also, there is a need to do `sudo apt-get install libmagic1` because as 'python-magic' is a wrapper around the libmagic C library then we need to install it too.

Depending on the OS there are different instructions to be followed. They are available at [python-magic project](https://github.com/ahupp/python-magic#installation) at github. An update to the doc's would deem useful.