### PR TITLE
Use `domain` over `endpoint` for configs.

### DIFF
--- a/cord/client.py
+++ b/cord/client.py
@@ -86,7 +86,8 @@ class CordClient(object):
         self._config: Config = config
 
     @staticmethod
-    def initialise(resource_id=None, api_key=None, endpoint=None) -> Union[CordClientProject, CordClientDataset]:
+    def initialise(resource_id: Optional[str] = None, api_key: Optional[str] = None, domain: Optional[str] = None) \
+            -> Union[CordClientProject, CordClientDataset]:
         """
         Create and initialize a Cord client from a resource ID and API key.
 
@@ -98,13 +99,13 @@ class CordClient(object):
                   If None, uses the CORD_DATASET_ID environment variable.
             api_key: An API key.
                      If None, uses the CORD_API_KEY environment variable.
-            endpoint: The cord api-server endpoint.
-                - If None, uses the CORD_ENDPOINT environmental variable
+            domain: The cord api-server domain.
+                If None, the CORD_DOMAIN is used
 
         Returns:
             CordClient: A Cord client instance.
         """
-        config = CordConfig(resource_id, api_key, endpoint)
+        config = CordConfig(resource_id, api_key, domain=domain)
         return CordClient.initialise_with_config(config)
 
     @staticmethod


### PR DESCRIPTION
If you have a CordClient you could query the `domain` of the CordUserClient and use it directly. If we keep on using the `endpoint` only, then whenever the `CordClient` would like to re-use the `CordUserClient` domain, it would have to strip the `/public/user` part of the `endpoint`'s url.