### PR TITLE
Fix bug around invalid CordClient initialisation with missing domain

### DIFF
--- a/cord/client.py
+++ b/cord/client.py
@@ -43,7 +43,7 @@ from pathlib import Path
 from typing import List, Tuple, Union, Optional
 
 import cord.exceptions
-from cord.configs import CordConfig, Config
+from cord.configs import CordConfig, Config, CORD_DOMAIN
 from cord.constants.model import *
 from cord.constants.string_constants import *
 from cord.http.querier import Querier
@@ -86,7 +86,7 @@ class CordClient(object):
 
     @staticmethod
     def initialise(
-        resource_id: Optional[str] = None, api_key: Optional[str] = None, domain: Optional[str] = None
+        resource_id: Optional[str] = None, api_key: Optional[str] = None, domain: str = CORD_DOMAIN
     ) -> Union[CordClientProject, CordClientDataset]:
         """
         Create and initialize a Cord client from a resource EntityId and API key.

--- a/cord/configs.py
+++ b/cord/configs.py
@@ -129,7 +129,7 @@ def get_env_api_key() -> str:
 
 
 class CordConfig(Config):
-    def __init__(self, resource_id: Optional[str] = None, api_key: Optional[str] = None, domain: str = CORD_DOMAIN):
+    def __init__(self, resource_id: Optional[str] = None, api_key: Optional[str] = None, domain: Optional[str] = None):
         web_file_path = CORD_PUBLIC_PATH
         super().__init__(resource_id, api_key, web_file_path=web_file_path, domain=domain)
 


### PR DESCRIPTION
Without that, what would happen is that the `None` from the `initialise` call would be passed to the `CordConfig.__init__` which would overwrite the `CordConfig.__init__` default value.