### PR TITLE
Dev 397 add slack notifications for sdk pipeline

### DIFF
--- a/.github/actions/send-slack-notification/action.yml
+++ b/.github/actions/send-slack-notification/action.yml
@@ -1,0 +1,63 @@
+name: "Send Slack message"
+description: "Send Slack message on success/failure parameter"
+
+inputs:
+  success-parameter:
+    description: "Pass success or failure here"
+    required: true
+  success-channel:
+    description: "Channel ID for sending success notifications"
+    required: false
+    default: ''
+  failure-channel:
+    description: "Channel ID for sending failure notifications"
+    required: false
+    default: ''
+  success-message:
+    description: "Message body on success"
+    required: false
+    default: ''
+  failure-message:
+    description: "Message body on failure"
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+
+  steps:
+    - uses: slackapi/slack-github-action@v1.18.0
+      if: inputs.success-parameter == 'success' && inputs.success-channel != ''
+      with:
+        channel-id: ${{ inputs.success-channel }}
+        payload: |
+          {
+            "text": "Success",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":white_check_mark: Success: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{ github.workflow }}>\n:memo: Commit: <${{ github.event.head_commit.url }}|${{ github.ref_name }}>\n:hatching_chick: What's new: ${{ github.event.head_commit.message }}\n\n${{ inputs.success-message }}"
+                }
+              }
+            ]
+          }
+
+    - uses: slackapi/slack-github-action@v1.18.0
+      if: inputs.success-parameter == 'failure' && inputs.failure-channel != ''
+      with:
+        channel-id: ${{ inputs.failure-channel }}
+        payload: |
+          {
+            "text": "Failure",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":exclamation: FAILURE: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{ github.workflow }}>\n:memo: Commit: <${{ github.event.head_commit.url }}|${{ github.ref_name }}>\n:beetle: Issue: ${{ github.event.head_commit.message }}\n\n${{ inputs.failure-message }}"
+                }
+              }
+            ]
+          }

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          exit 1
           poetry install --no-interaction
 
       - name: Build SDK

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -1,8 +1,11 @@
 name: Publish SDK
 
 on:
-  release:
-    types: [ published ]
+  push:
+    branches:
+    - DEV-397-add-slack-notifications-for-sdk-pipeline
+#  release:
+#    types: [ published ]
 
 env:
   PYTHON: 3.7.12
@@ -38,7 +41,30 @@ jobs:
       - name: Build SDK
         run: poetry build
 
-      - name: Publish SDK
-        run: |
-          poetry config pypi-token.pypi ${{ env.PYPI_TOKEN }}
-          poetry publish
+#      - name: Publish SDK
+#        run: |
+#          poetry config pypi-token.pypi ${{ env.PYPI_TOKEN }}
+#          poetry publish --dry-run
+
+  send-slack-notification:
+    name: Send notification
+    runs-on: ubuntu-latest
+    needs: [ publish-sdk ]
+    if: always()
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get workflow status
+        uses: technote-space/workflow-conclusion-action@v2
+
+      - name: Send Slack notification
+        uses: ./.github/actions/send-slack-notification
+        with:
+          success-parameter: ${{ env.WORKFLOW_CONCLUSION }}
+          success-channel: ${{ secrets.SLACK_DEPLOYMENT_PROD_CHANNEL_ID }}
+          failure-channel: ${{ secrets.SLACK_FAILURE_CHANNEL_ID }}
+          success-message: Deployed to https://pypi.org/project/cord-client-python/
+          failure-message: This pipeline has failed!

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-        exit 1
-        poetry install --no-interaction
+          exit 1
+          poetry install --no-interaction
 
       - name: Build SDK
         run: poetry build

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -36,7 +36,9 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Install dependencies
-        run: poetry install --no-interaction
+        run: |
+        exit 1
+        poetry install --no-interaction
 
       - name: Build SDK
         run: poetry build

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -1,11 +1,8 @@
 name: Publish SDK
 
 on:
-  push:
-    branches:
-    - DEV-397-add-slack-notifications-for-sdk-pipeline
-#  release:
-#    types: [ published ]
+  release:
+    types: [ published ]
 
 env:
   PYTHON: 3.7.12
@@ -43,10 +40,10 @@ jobs:
       - name: Build SDK
         run: poetry build
 
-#      - name: Publish SDK
-#        run: |
-#          poetry config pypi-token.pypi ${{ env.PYPI_TOKEN }}
-#          poetry publish --dry-run
+      - name: Publish SDK
+        run: |
+          poetry config pypi-token.pypi ${{ env.PYPI_TOKEN }}
+          poetry publish
 
   send-slack-notification:
     name: Send notification

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -3,7 +3,7 @@ name: Test SDK
 on:
   push:
     branches:
-      - DEV-397-add-slack-notifications-for-sdk-pipeline
+      - master
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Run tests
         run: |
-          exit 1
           source .venv/bin/activate
           python -m pytest tests --verbose --junitxml=${{ env.UNIT_TEST_REPORT }}
 

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -3,7 +3,7 @@ name: Test SDK
 on:
   push:
     branches:
-      - master
+      - DEV-397-add-slack-notifications-for-sdk-pipeline
   workflow_dispatch:
 
 env:
@@ -47,6 +47,7 @@ jobs:
 
       - name: Run tests
         run: |
+          exit 1
           source .venv/bin/activate
           python -m pytest tests --verbose --junitxml=${{ env.UNIT_TEST_REPORT }}
 
@@ -135,3 +136,24 @@ jobs:
           with:
             files: ${{ env.SDK_TEST_REPORT }}/*.xml
             check_name: SDK integration test report
+
+  send-slack-notification:
+    name: Send notification
+    runs-on: ubuntu-latest
+    needs: [ publish-test-reports ]
+    if: always()
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get workflow status
+        uses: technote-space/workflow-conclusion-action@v2
+
+      - name: Send Slack notification
+        uses: ./.github/actions/send-slack-notification
+        with:
+          success-parameter: ${{ env.WORKFLOW_CONCLUSION }}
+          failure-channel: ${{ secrets.SLACK_FAILURE_CHANNEL_ID }}
+          failure-message: This pipeline has failed!


### PR DESCRIPTION
Overview
- Added notifications to SDK test and publish pipelines
- SDK test pipeline only notifies on failure (to pipeline-failures-sdk)
- Publish pipeline notifies to deployments-sdk on success and pipeline-failures-sdk on failures

Testing
- Change events to on push to feature branch
- Tested success and failures to test channels